### PR TITLE
Changed price-calculation for variant-articles (rss)

### DIFF
--- a/source/Application/Model/RssFeed.php
+++ b/source/Application/Model/RssFeed.php
@@ -238,10 +238,20 @@ class RssFeed extends \oxSuperCfg
             $oItem = new stdClass();
             $oActCur = $this->getConfig()->getActShopCurrencyObject();
             $sPrice = '';
-            if ($oPrice = $oArticle->getPrice()) {
-                $sFrom = ($oArticle->isRangePrice()) ? Registry::getLang()->translateString('PRICE_FROM')." " : '';
+            
+            // check if article is a variant
+            if ($oArticle->isParentNotBuyable()) {
+                $oPrice = $oArticle->getVarMinPrice();
+            }
+            else {
+                $oPrice = $oArticle->getPrice();
+            }
+
+            if ($oPrice) {
+                $sFrom = ($oArticle->isRangePrice()) ? Registry::getLang()->translateString('PRICE_FROM') . " " : '';
                 $sPrice .= ' ' . $sFrom . $oLang->formatCurrency($oPrice->getBruttoPrice(), $oActCur) . " " . $oActCur->sign;
             }
+            
             $oItem->title = strip_tags($oArticle->oxarticles__oxtitle->value . $sPrice);
             $oItem->guid = $oItem->link = $myUtilsUrl->prepareUrlForNoSession($oArticle->getLink());
             $oItem->isGuidPermalink = true;


### PR DESCRIPTION
Added a check if the parent article is buyable.
If not, the varMinPrice is taken instead of the price of the parent article.